### PR TITLE
Add vterm configuration and shell setup documentation

### DIFF
--- a/.emacs.d/Emacs.org
+++ b/.emacs.d/Emacs.org
@@ -1179,7 +1179,68 @@ For markdown style checking and linting:
     :hook (prog-mode . git-gutter-mode)
     :config
     (setq git-gutter:update-interval 0.02))
+
+  ;; Git Time Machine - Step through historic versions of git controlled files
+  (use-package git-timemachine
+    :bind ("C-c g t" . git-timemachine)
+    :custom
+    ;; Show commit info when switching revisions
+    (git-timemachine-show-minibuffer-details t))
 #+end_src
+
+** Git Time Machine Reference
+Git Time Machine lets you step through historic revisions of any git-controlled file, seeing how the file changed over time.
+
+*** Key Features
+- Browse through git history of a file without checking out different commits
+- See commit messages and metadata for each revision
+- Copy content from historical versions
+- Compare changes between revisions
+- Works seamlessly with git-controlled files
+
+*** Key Bindings (when git-timemachine is active)
+| Key     | Command                                      | Description                          |
+|---------+----------------------------------------------+--------------------------------------|
+| ~p~     | git-timemachine-show-previous-revision      | Show previous revision               |
+| ~n~     | git-timemachine-show-next-revision          | Show next revision                   |
+| ~g~     | git-timemachine-show-nth-revision           | Go to nth revision                   |
+| ~t~     | git-timemachine-show-revision               | Go to specific revision by hash      |
+| ~q~     | git-timemachine-quit                        | Exit git time machine                |
+| ~w~     | git-timemachine-kill-abbreviated-revision   | Copy abbreviated revision hash       |
+| ~W~     | git-timemachine-kill-revision               | Copy full revision hash              |
+| ~b~     | git-timemachine-blame                       | Show git blame for current revision  |
+| ~c~     | git-timemachine-show-commit                 | Show commit information              |
+| ~?~     | git-timemachine-help                        | Show help                            |
+
+*** Usage Workflow
+1. Open any git-controlled file
+2. Run ~C-c g t~ (or ~M-x git-timemachine~)
+3. Use ~p~ and ~n~ to navigate through history
+4. The mode line shows: [Git Timemachine: <revision info>]
+5. Edit operations are disabled while browsing history
+6. Press ~q~ to return to the current version
+
+*** Advanced Features
+**** Copy Historical Content
+While viewing a historical revision:
+- Select text and copy as normal
+- Use ~w~ to copy the abbreviated commit hash
+- Use ~W~ to copy the full commit hash
+
+**** Integration with Magit
+- Press ~c~ while in time machine to view full commit details
+- Press ~b~ to see git blame for the historical version
+
+**** Finding Specific Changes
+1. Use ~g~ to jump to a specific revision number
+2. Use ~t~ to go to a revision by commit hash
+3. The minibuffer shows commit details when ~git-timemachine-show-minibuffer-details~ is enabled
+
+*** Tips
+- Git Time Machine creates a read-only buffer, so you can't accidentally modify historical content
+- The original buffer remains unchanged while browsing history
+- You can have multiple files open in git-timemachine mode simultaneously
+- Works with any VCS backend that git supports (including worktrees and submodules)
 
 * Tree-sitter Support
 Configures tree-sitter for enhanced syntax parsing and highlighting.
@@ -1345,21 +1406,21 @@ These variables are already set in our configuration, shown here for reference:
 
 ** Code
 #+begin_src emacs-lisp
-    (use-package claude-code
-      :straight (:type git :host github :repo "stevemolitor/claude-code.el" :branch "main"
-                       :files ("*.el" (:exclude "demo.gif")))
-      :bind-keymap
-      ("C-c C" . claude-code-command-map)
-      :hook ((claude-code--start . sm-setup-claude-faces))
-      :custom
-      (claude-code-program "/Users/rod/.claude/local/claude")
-      (claude-code-startup-delay 0.2)
-      ;; (claude-code-newline-keybinding-style 'shift-return-to-send)
-      :custom-face
-      (claude-code-repl-face ((t (:family "JuliaMono"))))
-      :config
-      ;; (setq claude-code-terminal-backend 'vterm)
-      (claude-code-mode))
+  (use-package claude-code
+    :straight (:type git :host github :repo "stevemolitor/claude-code.el" :branch "main"
+                     :files ("*.el" (:exclude "demo.gif")))
+    :bind-keymap
+    ("C-c C" . claude-code-command-map)
+    :hook ((claude-code--start . sm-setup-claude-faces))
+    :custom
+    (claude-code-program "/Users/rod/.claude/local/claude")
+    (claude-code-startup-delay 0.2)
+    ;; (claude-code-newline-keybinding-style 'shift-return-to-send)
+    :custom-face
+    (claude-code-repl-face ((t (:family "JuliaMono"))))
+    :config
+    (setq claude-code-terminal-backend 'vterm)
+    (claude-code-mode))
 #+end_src
 
 * Yasnippet

--- a/.emacs.d/Emacs.org
+++ b/.emacs.d/Emacs.org
@@ -525,7 +525,7 @@ Similar to Comint, Shell mode and Term line mode. Terminal input is sent one lin
 - ~C-c C-e~ - Switch to "emacs" input mode
 - ~C-c C-j~ - Switch to "semi-char" input mode
 - ~C-c M-d~ - Switch to "char" input mode
-  
+
 ** Code
 #+begin_src emacs-lisp
   ;; Install and configure eat
@@ -567,6 +567,211 @@ Similar to Comint, Shell mode and Term line mode. Terminal input is sent one lin
       (eat)))
 
   (global-set-key (kbd "C-c T") #'efs/eat-project)
+#+end_src
+
+* Vterm Terminal
+** Reference
+*** Overview
+Vterm is a fully-featured terminal emulator inside GNU Emacs based on libvterm, offering near-native terminal performance and compatibility. It provides better performance and compatibility than built-in alternatives like term-mode or ansi-term.
+
+*** Prerequisites
+**** System Requirements
+- Emacs compiled with module support (check with ~(module-file-p "test")~)
+- CMake (for building the module)
+- libtool
+- C compiler (gcc or clang)
+
+**** Installation on Different Systems
+***** MacOS
+#+begin_example
+brew install cmake libtool
+#+end_example
+
+***** Ubuntu/Debian
+#+begin_example
+sudo apt install cmake libtool-bin
+#+end_example
+
+***** Arch Linux
+#+begin_example
+sudo pacman -S cmake libtool
+#+end_example
+
+*** Key Features
+- Full terminal emulation with excellent compatibility
+- Native compilation for superior performance
+- Shell-side integration for directory tracking
+- Automatic shell configuration for zsh, bash, and fish
+- Copy mode for terminal text selection
+- Seamless integration with Emacs keybindings
+
+*** Key Bindings
+**** Normal Mode
+- ~C-c C-t~ - Toggle between char mode and copy mode
+- ~C-c C-n~ - Next prompt
+- ~C-c C-p~ - Previous prompt
+- ~C-c C-c~ - Send C-c to terminal
+- ~C-c C-z~ - Send C-z to terminal
+- ~C-c C-g~ - Send C-g to terminal
+- ~C-c C-u~ - Send C-u to terminal
+- ~C-c C-d~ - Send EOF to terminal
+- ~C-c C-l~ - Clear screen and scrollback
+- ~C-c C-\~ - Send quit signal
+- ~C-y~ - Yank (paste) in terminal
+
+**** Copy Mode
+Enter copy mode with ~C-c C-t~:
+- ~C-n/C-p~ - Move up/down
+- ~C-f/C-b~ - Move forward/backward
+- ~M-f/M-b~ - Move by word
+- ~C-a/C-e~ - Beginning/end of line
+- ~C-v/M-v~ - Page down/up
+- ~C-SPC~ - Set mark
+- ~C-w~ - Copy region
+- ~M-w~ - Copy region and exit copy mode
+- ~C-g~ - Exit copy mode
+- ~RET~ - Copy line and exit copy mode
+
+*** Configuration Options
+**** Terminal Settings
+- ~vterm-max-scrollback~ - Maximum scrollback lines (default: 1000)
+- ~vterm-kill-buffer-on-exit~ - Kill buffer when process exits
+- ~vterm-clear-scrollback-when-clearing~ - Clear scrollback with terminal clear
+
+**** Shell Integration
+- ~vterm-shell~ - Shell to use (defaults to ~$SHELL~)
+- ~vterm-always-compile-module~ - Always recompile the module
+
+**** Display Settings
+- ~vterm-term-environment-variable~ - Terminal type to report (default: "xterm-256color")
+- ~vterm-disable-underline~ - Disable underline
+- ~vterm-disable-inverse-video~ - Disable inverse video
+
+*** Advanced Features
+**** Directory Tracking
+Vterm automatically tracks the current directory using shell integration. This enables:
+- Opening files relative to the terminal's working directory
+- Syncing Emacs' default-directory with the shell
+
+**** Multiple Vterm Buffers
+Use ~vterm-other-window~ to create vterm buffers in other windows. Each vterm buffer is independent with its own shell process.
+
+**** Integration with project.el
+The configuration includes ~efs/vterm-project~ function that opens vterm in the project root directory, similar to the eat terminal integration.
+
+*** Tips and Tricks
+1. **Performance**: Vterm is significantly faster than other Emacs terminal emulators for operations like:
+   - Large output streams
+   - Full-screen terminal applications (htop, vim, etc.)
+   - Colored output and ANSI escape sequences
+
+2. **Copy Mode**: Use copy mode (~C-c C-t~) to select and copy text with familiar Emacs keybindings
+
+3. **Shell Configuration**: Vterm automatically configures your shell with enhanced features:
+   - Directory tracking
+   - Prompt detection
+   - Clear command integration
+
+4. **Compilation**: The vterm module will be compiled automatically on first use. If you encounter issues, you can manually compile with ~M-x vterm-module-compile~
+
+*** Troubleshooting
+1. **Module compilation fails**: Ensure you have all prerequisites installed (cmake, libtool, compiler)
+
+2. **Performance issues**: Check ~vterm-timer-delay~ (default: 0.1) - lower values mean more responsive but higher CPU usage
+
+3. **Display issues**: Try toggling ~vterm-disable-underline~ or ~vterm-disable-inverse-video~
+
+4. **Shell integration not working**: Vterm automatically installs shell configuration files. Check ~/.emacs_vterm_* files exist
+
+5. **Custom shell configuration**: See [[file:vterm-shell-config.org][Vterm Shell Configuration]] for detailed setup of prompt and git integration in your shell
+
+** Code
+#+begin_src emacs-lisp
+  ;; Vterm - Fully-featured terminal emulator
+  (use-package vterm
+    :commands vterm
+    :custom
+    ;; Terminal behavior
+    (vterm-max-scrollback 10000)
+    (vterm-kill-buffer-on-exit t)
+    (vterm-clear-scrollback-when-clearing t)
+
+    ;; Shell settings
+    (vterm-shell (getenv "SHELL"))
+
+    ;; Display settings
+    (vterm-term-environment-variable "xterm-256color")
+
+    ;; Performance tuning
+    (vterm-timer-delay 0.01)
+
+    ;; Disable automatic shell configuration to prevent prompt issues
+    (vterm-environment '("INSIDE_EMACS=vterm"))
+
+    :config
+    ;; Set up vterm buffer display
+    (add-to-list 'display-buffer-alist
+                 '("\\*vterm\\*"
+                   (display-buffer-reuse-window display-buffer-same-window)))
+
+    ;; Project-specific vterm launcher
+    (defun efs/vterm-project ()
+      "Open vterm in the current project root directory."
+      (interactive)
+      (if-let* ((project (project-current))
+                (root (project-root project))
+                (project-name (project-name project))
+                (buffer-name (format "*%s-vterm*" project-name)))
+          (if (get-buffer buffer-name)
+              (pop-to-buffer buffer-name)
+            (let ((default-directory root))
+              (vterm buffer-name)))
+        (user-error "Not in a project")))
+
+    ;; Helper function to send text to vterm
+    (defun efs/vterm-send-string (string)
+      "Send STRING to current vterm buffer."
+      (interactive "sText to send: ")
+      (vterm-send-string string))
+
+    ;; Helper to clear scrollback
+    (defun efs/vterm-clear-scrollback ()
+      "Clear vterm buffer and scrollback."
+      (interactive)
+      (vterm-clear)
+      (vterm-clear-scrollback))
+
+    :bind
+    (("C-c v" . vterm)
+     ("C-c V" . efs/vterm-project)
+     :map vterm-mode-map
+     ("C-c C-l" . efs/vterm-clear-scrollback)
+     ("C-q" . vterm-send-next-key)
+     ;; Make sure these don't interfere with terminal programs
+     ("M-1" . nil)
+     ("M-2" . nil)
+     ("M-3" . nil)
+     ("M-4" . nil)
+     ("M-5" . nil)
+     ("M-6" . nil)
+     ("M-7" . nil)
+     ("M-8" . nil)
+     ("M-9" . nil)
+     ("M-0" . nil)))
+
+  ;; Optional: vterm-toggle for quick terminal access
+  (use-package vterm-toggle
+    :after vterm
+    :bind
+    (("C-c `" . vterm-toggle)
+     ("C-c ~" . vterm-toggle-cd)
+     :map vterm-mode-map
+     ("s-n" . vterm-toggle-forward)
+     ("s-p" . vterm-toggle-backward))
+    :custom
+    (vterm-toggle-scope 'project)
+    (vterm-toggle-fullscreen-p nil)
+    (vterm-toggle-reset-window-configration-after-exit t))
 #+end_src
 
 * Org Mode
@@ -901,7 +1106,7 @@ For markdown style checking and linting:
     (add-hook 'markdown-mode-hook (lambda ()
                                     (setq visual-fill-column-width efs/default-fill-column)
                                     (visual-fill-column-mode 1)))
-    
+
     ;; Key bindings
     :bind (:map markdown-mode-map
            ("C-c C-s a" . markdown-table-align)  ;; Align tables
@@ -1005,7 +1210,7 @@ Configures tree-sitter for enhanced syntax parsing and highlighting.
             (js-mode . js-ts-mode)
             (js2-mode . js-ts-mode)
             (go-mode . go-ts-mode)))
-    
+
     ;; For SQL mode, we need to ensure sql-mode is loaded before remapping
     ;; Otherwise we get "Ignoring unknown mode 'sql-mode'" errors
     (with-eval-after-load 'sql
@@ -1140,20 +1345,21 @@ These variables are already set in our configuration, shown here for reference:
 
 ** Code
 #+begin_src emacs-lisp
-  (use-package claude-code
-    :straight (:type git :host github :repo "stevemolitor/claude-code.el" :branch "main"
-                     :files ("*.el" (:exclude "demo.gif")))
-    :bind-keymap
-    ("C-c C" . claude-code-command-map)
-    :hook ((claude-code--start . sm-setup-claude-faces))
-    :custom
-    (claude-code-program "/Users/rod/.claude/local/claude")
-    (claude-code-startup-delay 0.2)
-    (claude-code-newline-keybinding-style 'shift-return-to-send)
-    :custom-face
-    (claude-code-repl-face ((t (:family "JuliaMono"))))
-    :config
-    (claude-code-mode))
+    (use-package claude-code
+      :straight (:type git :host github :repo "stevemolitor/claude-code.el" :branch "main"
+                       :files ("*.el" (:exclude "demo.gif")))
+      :bind-keymap
+      ("C-c C" . claude-code-command-map)
+      :hook ((claude-code--start . sm-setup-claude-faces))
+      :custom
+      (claude-code-program "/Users/rod/.claude/local/claude")
+      (claude-code-startup-delay 0.2)
+      ;; (claude-code-newline-keybinding-style 'shift-return-to-send)
+      :custom-face
+      (claude-code-repl-face ((t (:family "JuliaMono"))))
+      :config
+      ;; (setq claude-code-terminal-backend 'vterm)
+      (claude-code-mode))
 #+end_src
 
 * Yasnippet

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -391,25 +391,25 @@
   (vterm-max-scrollback 10000)
   (vterm-kill-buffer-on-exit t)
   (vterm-clear-scrollback-when-clearing t)
-  
+
   ;; Shell settings
   (vterm-shell (getenv "SHELL"))
-  
+
   ;; Display settings
   (vterm-term-environment-variable "xterm-256color")
-  
+
   ;; Performance tuning
   (vterm-timer-delay 0.01)
-  
+
   ;; Disable automatic shell configuration to prevent prompt issues
   (vterm-environment '("INSIDE_EMACS=vterm"))
-  
+
   :config
   ;; Set up vterm buffer display
   (add-to-list 'display-buffer-alist
                '("\\*vterm\\*"
                  (display-buffer-reuse-window display-buffer-same-window)))
-  
+
   ;; Project-specific vterm launcher
   (defun efs/vterm-project ()
     "Open vterm in the current project root directory."
@@ -423,20 +423,20 @@
           (let ((default-directory root))
             (vterm buffer-name)))
       (user-error "Not in a project")))
-  
+
   ;; Helper function to send text to vterm
   (defun efs/vterm-send-string (string)
     "Send STRING to current vterm buffer."
     (interactive "sText to send: ")
     (vterm-send-string string))
-  
+
   ;; Helper to clear scrollback
   (defun efs/vterm-clear-scrollback ()
     "Clear vterm buffer and scrollback."
     (interactive)
     (vterm-clear)
     (vterm-clear-scrollback))
-  
+
   :bind
   (("C-c v" . vterm)
    ("C-c V" . efs/vterm-project)
@@ -715,7 +715,7 @@
   (add-hook 'markdown-mode-hook (lambda ()
                                   (setq visual-fill-column-width efs/default-fill-column)
                                   (visual-fill-column-mode 1)))
-  
+
   ;; Key bindings
   :bind (:map markdown-mode-map
          ("C-c C-s a" . markdown-table-align)  ;; Align tables
@@ -811,7 +811,7 @@
           (js-mode . js-ts-mode)
           (js2-mode . js-ts-mode)
           (go-mode . go-ts-mode)))
-  
+
   ;; For SQL mode, we need to ensure sql-mode is loaded before remapping
   ;; Otherwise we get "Ignoring unknown mode 'sql-mode'" errors
   (with-eval-after-load 'sql
@@ -886,7 +886,7 @@
   :custom-face
   (claude-code-repl-face ((t (:family "JuliaMono"))))
   :config
-  ;; (setq claude-code-terminal-backend 'vterm)
+  (setq claude-code-terminal-backend 'vterm)
   (claude-code-mode))
 
 (use-package yasnippet

--- a/.emacs.d/vterm-shell-config.org
+++ b/.emacs.d/vterm-shell-config.org
@@ -1,0 +1,161 @@
+#+TITLE: Vterm Shell Configuration
+#+AUTHOR: Your Name
+#+DATE: 2025-07-24
+
+* Shell Configuration for Vterm
+
+Vterm requires special shell configuration to work properly. The shell needs to detect when it's running inside vterm and adjust its behavior accordingly.
+
+** Zsh Configuration (.zshrc)
+
+Add this to your ~~/.zshrc~ file:
+
+#+begin_src shell
+# vterm configuration
+if [[ "$INSIDE_EMACS" = 'vterm' ]] || [[ "$INSIDE_EMACS" = *"vterm"* ]]; then
+    # Disable partial line indicators in vterm
+    unsetopt PROMPT_CR
+    unsetopt PROMPT_SP
+
+    # Git prompt function
+    git_prompt_info() {
+        local branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+        if [[ -n $branch ]]; then
+            local git_status=""
+            # Check for uncommitted changes
+            if ! git diff --quiet 2>/dev/null; then
+                git_status="*"
+            fi
+            # Check for staged changes
+            if ! git diff --cached --quiet 2>/dev/null; then
+                git_status="${git_status}+"
+            fi
+            # Check for untracked files
+            if [[ -n $(git ls-files --others --exclude-standard 2>/dev/null) ]]; then
+                git_status="${git_status}?"
+            fi
+            echo " ($branch$git_status)"
+        fi
+    }
+
+    # Use a simple prompt for vterm with git info
+    setopt PROMPT_SUBST
+    PROMPT='%n@%m %~ $(git_prompt_info) %# '
+
+    # Vterm directory tracking function
+    vterm_printf() {
+        if [ -n "$TMUX" ] && { [ "${TERM%%-*}" = "tmux" ] || [ "${TERM%%-*}" = "screen" ]; }; then
+            # Tell tmux to pass the escape sequences through
+            printf "\ePtmux;\e\e]%s\007\e\\" "$1"
+        elif [ "${TERM%%-*}" = "screen" ]; then
+            # GNU screen (screen, screen-256color, screen-256color-bce)
+            printf "\eP\e]%s\007\e\\" "$1"
+        else
+            printf "\e]%s\e\\" "$1"
+        fi
+    }
+
+    # Directory tracking
+    vterm_prompt_end() {
+        vterm_printf "51;A$(whoami)@$(hostname):$(pwd)"
+    }
+    PROMPT=$PROMPT'%{$(vterm_prompt_end)%}'
+else
+    # Load your regular prompt (e.g., starship) when NOT in vterm
+    eval "$(starship init zsh)"
+fi
+#+end_src
+
+** Bash Configuration (.bashrc)
+
+For bash users, add this to your ~~/.bashrc~ file:
+
+#+begin_src shell
+# vterm configuration
+if [[ "$INSIDE_EMACS" = 'vterm' ]] || [[ "$INSIDE_EMACS" = *"vterm"* ]]; then
+    # Git prompt function
+    git_prompt_info() {
+        local branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+        if [[ -n $branch ]]; then
+            local git_status=""
+            # Check for uncommitted changes
+            if ! git diff --quiet 2>/dev/null; then
+                git_status="*"
+            fi
+            # Check for staged changes
+            if ! git diff --cached --quiet 2>/dev/null; then
+                git_status="${git_status}+"
+            fi
+            # Check for untracked files
+            if [[ -n $(git ls-files --others --exclude-standard 2>/dev/null) ]]; then
+                git_status="${git_status}?"
+            fi
+            echo " ($branch$git_status)"
+        fi
+    }
+
+    # Use a simple prompt for vterm with git info
+    export PS1='\u@\h \w $(git_prompt_info) \$ '
+
+    # Vterm directory tracking function
+    vterm_printf() {
+        if [ -n "$TMUX" ] && { [ "${TERM%%-*}" = "tmux" ] || [ "${TERM%%-*}" = "screen" ]; }; then
+            printf "\ePtmux;\e\e]%s\007\e\\" "$1"
+        elif [ "${TERM%%-*}" = "screen" ]; then
+            printf "\eP\e]%s\007\e\\" "$1"
+        else
+            printf "\e]%s\e\\" "$1"
+        fi
+    }
+
+    # Directory tracking
+    vterm_prompt_end() {
+        vterm_printf "51;A$(whoami)@$(hostname):$(pwd)"
+    }
+    PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }vterm_prompt_end"
+else
+    # Load your regular prompt when NOT in vterm
+    eval "$(starship init bash)"
+fi
+#+end_src
+
+** Key Features
+
+*** Environment Detection
+The configuration checks ~$INSIDE_EMACS~ to detect when running in vterm. This allows you to have different configurations for vterm vs regular terminal.
+
+*** Prompt Customization
+Uses a simple prompt with git information inside vterm:
+- Shows username, hostname, current directory
+- Displays git branch name when in a repository
+- Shows git status indicators
+
+*** Directory Tracking
+The ~vterm_prompt_end~ function enables Emacs to track the current directory. This allows features like:
+- Opening files relative to the terminal's current directory
+- ~find-file~ starting in the terminal's pwd
+
+*** Git Status Indicators
+- ~*~ indicates uncommitted changes
+- ~+~ indicates staged changes
+- ~?~ indicates untracked files
+
+*** Partial Line Indicators (Zsh only)
+For zsh, ~unsetopt PROMPT_CR~ and ~unsetopt PROMPT_SP~ disable the ~%~ character that appears for incomplete lines.
+
+** Troubleshooting
+
+*** Prompt appears twice
+Make sure you're not sourcing shell configuration files multiple times. Check if vterm is auto-installing its own configuration.
+
+*** Git status not working
+Ensure git is in your PATH and the git commands have proper permissions.
+
+*** Directory tracking not working
+Check that the ~vterm_printf~ function is properly sending escape sequences. You can test with:
+#+begin_src shell
+vterm_printf "test"
+#+end_src
+
+*** Special characters in prompt
+If you see escape sequences in your prompt, your terminal might not support them. Try simplifying the prompt or checking terminal compatibility.


### PR DESCRIPTION
## Summary
- Added vterm terminal emulator configuration to Emacs
- Created comprehensive shell setup documentation for vterm integration
- Fixed trailing whitespace in modified files
- **NEW**: Added git-timemachine package for browsing git history

## Changes
### Vterm Configuration
- **Emacs configuration**: Added full vterm setup with project integration, key bindings, and helper functions
- **Documentation**: Created `vterm-shell-config.org` with detailed instructions for configuring zsh and bash shells to work properly with vterm
- **Shell features**: Documented prompt customization with git status indicators, directory tracking, and environment detection

### Git Time Machine (NEW)
- **Package Configuration**: Added git-timemachine to Version Control section with keybinding `C-c g t`
- **Documentation**: Added comprehensive reference section covering:
  - Key features and capabilities
  - Complete key bindings reference table
  - Step-by-step usage workflow
  - Advanced features (copying content, Magit integration)
  - Tips for effective usage

## Test plan
- [x] Test vterm launches successfully in Emacs
- [x] Verify shell prompt displays correctly without partial line indicators
- [x] Confirm git status indicators work in the prompt
- [x] Test directory tracking functionality
- [ ] Test on both zsh and bash shells
- [ ] Verify git-timemachine loads correctly with `C-c g t`
- [ ] Test navigation through file history with `p` and `n` keys
- [ ] Confirm commit details appear in minibuffer
- [ ] Verify all documented keybindings work as expected
- [ ] Check that documentation renders correctly in org-mode

🤖 Generated with [Claude Code](https://claude.ai/code)