### PR TITLE
Force Claude Code classic renderer under vterm

### DIFF
--- a/.emacs.d/Emacs.org
+++ b/.emacs.d/Emacs.org
@@ -1818,6 +1818,14 @@ These variables are already set in our configuration, shown here for reference:
     :config
     (setq claude-code-terminal-backend 'vterm)
 
+    ;; Force Claude Code's classic (native-scrollback) renderer under vterm.
+    ;; Fullscreen rendering (settings.json "tui": "fullscreen") draws on the
+    ;; terminal's alternate screen buffer, which vterm never saves to
+    ;; scrollback — so the buffer can only scroll one page. This env var
+    ;; overrides the saved tui setting for Emacs-launched Claude only, leaving
+    ;; fullscreen active in standalone terminals like iTerm.
+    (setenv "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN" "1")
+
     ;; Set claude-code face to use the same font settings as default with readable colors
     (set-face-attribute 'claude-code-repl-face nil
                         :family efs/fixed-font-family

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -1242,6 +1242,14 @@ _P_: skip prev    _d_: defun
     :config
     (setq claude-code-terminal-backend 'vterm)
 
+    ;; Force Claude Code's classic (native-scrollback) renderer under vterm.
+    ;; Fullscreen rendering (settings.json "tui": "fullscreen") draws on the
+    ;; terminal's alternate screen buffer, which vterm never saves to
+    ;; scrollback — so the buffer can only scroll one page. This env var
+    ;; overrides the saved tui setting for Emacs-launched Claude only, leaving
+    ;; fullscreen active in standalone terminals like iTerm.
+    (setenv "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN" "1")
+
     ;; Set claude-code face to use the same font settings as default with readable colors
     (set-face-attribute 'claude-code-repl-face nil
                         :family efs/fixed-font-family


### PR DESCRIPTION
## Problem

claude-code.el buffers (vterm backend) would only scroll back a single page — mouse wheel, `M-v`, and `M-<` all stopped after one screen.

The cause is Claude Code's **fullscreen rendering** (a research-preview TUI mode, persisted as `"tui": "fullscreen"` in `~/.claude/settings.json`, available since CLI v2.1.89). It draws the interface on the terminal's **alternate screen buffer**, like `vim`/`htop`. vterm never saves alt-screen content to scrollback, so from Emacs there's only ever one visible page to navigate — regardless of `vterm-max-scrollback`.

Ref: https://code.claude.com/docs/en/fullscreen

## Fix

Set `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` in the `claude-code` config. Per the docs, this forces the classic native-scrollback renderer "regardless of the saved tui setting." Because it's set in the Emacs process environment, only child vterm-launched Claude sessions inherit it — fullscreen rendering stays active in standalone terminals like iTerm.

After this change, vterm captures the full conversation into scrollback again and `vterm-max-scrollback` applies as expected.

## Notes

- Touches the `claude-code` `use-package` block in `Emacs.org`; `init.el` re-tangled.
- Requires restarting Emacs (or re-evaluating the `setenv`) and starting a fresh Claude buffer, since the env var is read at process launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)